### PR TITLE
Updated schedule subdomain and API version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The location of the config file can be specified with the `-c` option.
   "minimumDuration": 240000,
   "safetyBuffer": 40000,
   "saveDir": "/recordings/",
-  "scheduleUrl": "https://api.nhk.or.jp",
+  "scheduleUrl": "https://nwapi.nhk.jp",
   "streamUrl": "https://b-nhkwlive-ojp.webcdn.stream.ne.jp/hls/live/2003459-b/nhkwlive-ojp-en/index_4M.m3u8",
   "threadLimit": 0,
   "timeOffset": 0,

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
   "minimumDuration": 240000,
   "safetyBuffer": 40000,
   "saveDir": "/recordings/",
-  "scheduleUrl": "https://api.nhk.or.jp",
+  "scheduleUrl": "https://nwapi.nhk.jp",
   "streamUrl": "https://b-nhkwlive-ojp.webcdn.stream.ne.jp/hls/live/2003459-b/nhkwlive-ojp-en/index_4M.m3u8",
   "threadLimit": 0,
   "timeOffset": 0,

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -35,7 +35,7 @@ const getScheduleForPeriod = async (apiKey: string, start: Date, end: Date): Pro
   const endMillis = end.getTime();
 
   const res = await fetch(
-    `${config.scheduleUrl}/nhkworld/epg/v7a/world/s${startMillis}-e${endMillis}.json?apikey=${apiKey}`
+    `${config.scheduleUrl}/nhkworld/epg/v7b/world/s${startMillis}-e${endMillis}.json?apikey=${apiKey}`
   );
 
   return await res.json();


### PR DESCRIPTION
My instance of NHK-Record stopped working sometime last week. Turns out NHK World's Live API is now at version 7**b**, rooted at **nwapi.nhk.jp**

I rebuilt the docker image locally and have had it running for about a day and everything works as intended.

Thanks for the wonderful project!