### PR TITLE
Updating HLS stream URL

### DIFF
--- a/.github/workflows/dockerhub-image.yml
+++ b/.github/workflows/dockerhub-image.yml
@@ -1,0 +1,38 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: coordspace/nhk-record
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,5 +31,5 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: npx semantic-release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,7 @@ jobs:
         run: npm run test:ci
 
       - name: Publish unit test results
-        uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
+        uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()
         with:
-          github_token: ${{ secrets.GH_TOKEN }}
           files: test-output/**/*.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,5 +35,5 @@ jobs:
         uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
         if: always()
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_TOKEN }}
           files: test-output/**/*.xml

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ So please, watch the [relevant pull request](https://github.com/nhkrecord/nhk-re
 
 If you are running an existing instance of nhk-record that has stopped working, please update the "streamURL" variable located in your `config.json` to the URL as follows:
 
-`"streamUrl": "https://nhkwlive-xjp.akamaized.net/hls/live/2003458/nhkwlive-xjp-en/index_1M.m3u8",`
+`"streamUrl": "https://nhkwlive-xjp.akamaized.net/hls/live/2003458/nhkwlive-xjp-en/index_2M.m3u8",`
 
 ## Dependencies
 
@@ -107,7 +107,7 @@ The location of the config file can be specified with the `-c` option.
   "safetyBuffer": 40000,
   "saveDir": "/recordings/",
   "scheduleUrl": "https://nwapi.nhk.jp",
-  "streamUrl": "https://nhkwlive-xjp.akamaized.net/hls/live/2003458/nhkwlive-xjp-en/index_1M.m3u8",
+  "streamUrl": "https://nhkwlive-xjp.akamaized.net/hls/live/2003458/nhkwlive-xjp-en/index_2M.m3u8",
   "threadLimit": 0,
   "timeOffset": 0,
   "trim": true

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The location of the config file can be specified with the `-c` option.
   "minimumDuration": 240000,
   "safetyBuffer": 40000,
   "saveDir": "/recordings/",
-  "scheduleUrl": "https://api.nhk.or.jp",
+  "scheduleUrl": "https://nwapi.nhk.jp",
   "streamUrl": "https://b-nhkwlive-ojp.webcdn.stream.ne.jp/hls/live/2003459-b/nhkwlive-ojp-en/index_4M.m3u8",
   "threadLimit": 0,
   "timeOffset": 0,

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The location of the config file can be specified with the `-c` option.
   "safetyBuffer": 40000,
   "saveDir": "/recordings/",
   "scheduleUrl": "https://nwapi.nhk.jp",
-  "streamUrl": "https://b-nhkwlive-ojp.webcdn.stream.ne.jp/hls/live/2003459-b/nhkwlive-ojp-en/index_4M.m3u8",
+  "streamUrl": "https://nhkwlive-xjp.akamaized.net/hls/live/2003458/nhkwlive-xjp-en/index_1M.m3u8",
   "threadLimit": 0,
   "timeOffset": 0,
   "trim": true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # nhk-record
 
+Automated recording of NHK World's 24/7 live stream. This system records each show into an individual video file complete with metadata and formatted filenames. Supports filtering shows by title so it records only what you want to watch. 
+
+This is an unofficial fan work made for personal use only. This project is in no way affiliated with NHK, NHK World, Japan International Broadcasting, Inc. or any other entities therein.
+
 ## Dependencies
 
 - [Node.js](https://github.com/nodejs/node) `>= 15.x`
@@ -10,7 +14,7 @@ This software is only tested on Linux and macOS. For running on Windows, [Docker
 ## Installing
 
 ```
-git clone git@github.com:nhkrecord/nhk-record.git
+git clone git@github.com:CoordSpace/nhk-record.git
 cd nhk-record
 npm install
 ```
@@ -110,7 +114,7 @@ Match patterns use [micromatch](https://github.com/micromatch/micromatch). For e
 
 ## Running as a docker container
 
-Docker images are available on [Docker Hub](https://hub.docker.com/r/nhkrecord/nhk-record)
+Docker images are available on [Docker Hub](https://hub.docker.com/repository/docker/coordspace/nhk-record)
 
 Example docker-compose.yml:
 
@@ -118,7 +122,7 @@ Example docker-compose.yml:
 version: "3.7"
 services:
   nhk-record:
-    image: nhkrecord/nhk-record:latest
+    image: coordspace/nhk-record:latest
     restart: unless-stopped
     volumes:
       - "/path/to/my/config.json:/config.json:ro"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Automated recording of NHK World's 24/7 live stream. This system records each sh
 
 This is an unofficial fan work made for personal use only. This project is in no way affiliated with NHK, NHK World, Japan International Broadcasting, Inc. or any other entities therein.
 
+## Note
+
+This is a maintenance fork of [nhkrecord/nhk-record](https://github.com/nhkrecord/nhk-record), created after NHK updated some core API endpoints. Do not expect any new features and if the original maintainer returns to the upstream project someday, it will be recommended to go back to using their repo after my fixes are pulled. 
+
+So please, watch the [relevant pull request](https://github.com/nhkrecord/nhk-record/pull/35) for any updates.
+
 ## Dependencies
 
 - [Node.js](https://github.com/nodejs/node) `>= 15.x`

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ This is a maintenance fork of [nhkrecord/nhk-record](https://github.com/nhkrecor
 
 So please, watch the [relevant pull request](https://github.com/nhkrecord/nhk-record/pull/35) for any updates.
 
+## Config Change Notice
+
+If you are running an existing instance of nhk-record that has stopped working, please update the "streamURL" variable located in your `config.json` to the URL as follows:
+
+`"streamUrl": "https://nhkwlive-xjp.akamaized.net/hls/live/2003458/nhkwlive-xjp-en/index_1M.m3u8",`
+
 ## Dependencies
 
 - [Node.js](https://github.com/nodejs/node) `>= 15.x`

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
   "safetyBuffer": 40000,
   "saveDir": "/recordings/",
   "scheduleUrl": "https://nwapi.nhk.jp",
-  "streamUrl": "https://b-nhkwlive-ojp.webcdn.stream.ne.jp/hls/live/2003459-b/nhkwlive-ojp-en/index_4M.m3u8",
+  "streamUrl": "https://nhkwlive-xjp.akamaized.net/hls/live/2003458/nhkwlive-xjp-en/index_1M.m3u8",
   "threadLimit": 0,
   "timeOffset": 0,
   "trim": true

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
   "safetyBuffer": 40000,
   "saveDir": "/recordings/",
   "scheduleUrl": "https://nwapi.nhk.jp",
-  "streamUrl": "https://nhkwlive-xjp.akamaized.net/hls/live/2003458/nhkwlive-xjp-en/index_1M.m3u8",
+  "streamUrl": "https://nhkwlive-xjp.akamaized.net/hls/live/2003458/nhkwlive-xjp-en/index_2M.m3u8",
   "threadLimit": 0,
   "timeOffset": 0,
   "trim": true

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
   "minimumDuration": 240000,
   "safetyBuffer": 40000,
   "saveDir": "/recordings/",
-  "scheduleUrl": "https://api.nhk.or.jp",
+  "scheduleUrl": "https://nwapi.nhk.jp",
   "streamUrl": "https://b-nhkwlive-ojp.webcdn.stream.ne.jp/hls/live/2003459-b/nhkwlive-ojp-en/index_4M.m3u8",
   "threadLimit": 0,
   "timeOffset": 0,

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -35,7 +35,7 @@ const getScheduleForPeriod = async (apiKey: string, start: Date, end: Date): Pro
   const endMillis = end.getTime();
 
   const res = await fetch(
-    `${config.scheduleUrl}/nhkworld/epg/v7a/world/s${startMillis}-e${endMillis}.json?apikey=${apiKey}`
+    `${config.scheduleUrl}/nhkworld/epg/v7b/world/s${startMillis}-e${endMillis}.json?apikey=${apiKey}`
   );
 
   return await res.json();


### PR DESCRIPTION
The NHK backend has been experiencing a lot of changes over the last 2 months. Most of it was focused on the VOD content, breaking many downloader/archive tools in the process.

Now it seems that the high bitrate "4M" stream has been discontinued alongside from URL path and subdomain changes.

This patch updates the docs and sample config to contain the new, highest bitrate HLS stream (1M) that NHK currently offers as far as I am aware. 

Existing installs will need to update their streamURL as follows:

`  "streamUrl": "https://nhkwlive-xjp.akamaized.net/hls/live/2003458/nhkwlive-xjp-en/index_1M.m3u8",`